### PR TITLE
CI: restore the 32-bit GCC 12 C++17/20 Drone stage, and name the split stages

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -170,7 +170,7 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
     ),
 
     linux_pipeline(
-        "Linux 24.04 GCC 13 32/64 UBSAN",
+        "Linux 24.04 GCC 13 32/64 UBSAN C++2b",
         "cppalliance/droneubuntu2404:1",
         { TOOLSET: 'gcc', COMPILER: 'g++-13', CXXSTD: '2b', ADDRMD: '32,64' } + ubsan,
         "g++-13-multilib",
@@ -191,7 +191,7 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
     ),
 
     linux_pipeline(
-        "Linux 24.04 GCC 13 32 ASAN",
+        "Linux 24.04 GCC 13 32 ASAN C++2b",
         "cppalliance/droneubuntu2404:1",
         { TOOLSET: 'gcc', COMPILER: 'g++-13', CXXSTD: '2b', ADDRMD: '32' } + asan,
         "g++-13-multilib",
@@ -212,7 +212,7 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
     ),
 
     linux_pipeline(
-        "Linux 24.04 GCC 14 UBSAN",
+        "Linux 24.04 GCC 14 UBSAN C++2b",
         "cppalliance/droneubuntu2404:1",
         { TOOLSET: 'gcc', COMPILER: 'g++-14', CXXSTD: '2b' } + ubsan,
         "g++-14-multilib",
@@ -233,7 +233,7 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
     ),
 
     linux_pipeline(
-        "Linux 24.04 GCC 14 ASAN",
+        "Linux 24.04 GCC 14 ASAN C++2b",
         "cppalliance/droneubuntu2404:1",
         { TOOLSET: 'gcc', COMPILER: 'g++-14', CXXSTD: '2b' } + asan,
         "g++-14-multilib",

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -144,6 +144,13 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
     linux_pipeline(
         "Linux 22.04 GCC 12 32/64 C++17-20",
         "cppalliance/droneubuntu2204:1",
+        { TOOLSET: 'gcc', COMPILER: 'g++-12', CXXSTD: '17,20', ADDRMD: '32,64' },
+        "g++-12-multilib",
+    ),
+
+    linux_pipeline(
+        "Linux 22.04 GCC 12 32/64 C++2b",
+        "cppalliance/droneubuntu2204:1",
         { TOOLSET: 'gcc', COMPILER: 'g++-12', CXXSTD: '2b', ADDRMD: '32,64' },
         "g++-12-multilib",
     ),


### PR DESCRIPTION
Two Drone-only changes. `.drone.jsonnet` is the only file touched.

### Restore the 32-bit GCC 12 C++17/20 stage

There were two GCC 12 stages and both were misnamed: `"C++11-14"` ran
`CXXSTD: '17,20'`, and `"C++17-20"` ran `'2b'`. e520c1d corrected the first
name, which made the two names identical; dd2c40d then resolved the clash by
deleting one of the pair — the `17,20` one — leaving the `2b` stage wearing
the `17,20` label.

Net effect: **GCC 12 at C++17/20 stopped being built for 32 bits anywhere.**
The GHA matrix covers gcc-12 at those standards, but 64-bit only.

This restores the deleted stage and names the survivor for the standard it
actually runs. `17,20` stays bundled in one stage, matching the neighbouring
GCC 11 stage (`17,2a × 32/64`), which sits well inside the 60-minute Drone
step limit that f886630 and 44d0d61 split the heavier stages to respect.

### Name the split stages for the standard they run

f886630 and 44d0d61 split the heavy sanitizer stages one standard per stage,
naming the new ones `C++17`/`C++20` but leaving the original of each trio
unnamed — so `GCC 14 UBSAN C++17`, `GCC 14 UBSAN C++20`, and a bare
`GCC 14 UBSAN` that is in fact the `2b` run and reads like the whole set.
Four stages were in that shape. Names only; no environment, matrix or
coverage change.

This is the same ambiguity that let dd2c40d delete the wrong member of the
GCC 12 pair.

### Verification

Evaluated `.drone.jsonnet` with jsonnet locally: **35 → 36 pipelines**, all
pipeline names unique, no bare name left inside a split group, and every
stage name that states a standard matches its `CXXSTD`. Not exercised on
Drone — that is what this PR is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZvWvMxJsHkK4n5unJfx52